### PR TITLE
Docker: revised wsl$ detection for win11 and output_dir change code imporved

### DIFF
--- a/CfdOF/CfdPreferencePage.py
+++ b/CfdOF/CfdPreferencePage.py
@@ -259,10 +259,6 @@ class CfdPreferencePage:
 
     def outputDirChanged(self, text):
         self.output_dir = text
-        # Need to restart docker container if running
-        if CfdTools.docker_container is not None and CfdTools.docker_container.container_id!=None:
-            CfdTools.docker_container.stop_container()
-        CfdTools.docker_container = None
 
     def chooseOutputDir(self):
         d = QtGui.QFileDialog().getExistingDirectory(None, 'Choose output directory', self.output_dir)

--- a/CfdOF/CfdPreferencePage.py
+++ b/CfdOF/CfdPreferencePage.py
@@ -188,7 +188,7 @@ class CfdPreferencePage:
         # Set usedocker and enable/disable download buttons 
         self.dockerCheckboxClicked()
 
-        self.form.le_docker_url.setText(DOCKER_URL)
+        self.form.le_docker_url.setText(FreeCAD.ParamGet(prefs).GetString("DockerURL", DOCKER_URL))
 
         self.setDownloadURLs()
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The prefered docker run-time for Windows is via [podman](https://podman.io/) as 
 4. Edit &rarr; Preferences &rarr; CfdOF: Select _Use docker_.
 5. Press the _Install Docker Container_ button. There is no need to install gmsh, cfmesh and HISA as they are included in the docker image.
 6. If using podman, fast WSL file system integration can be enabled:
-   * Create a new subdirectory (for example `cfdof`) in the following firectory created by podman: 
+   * Create a new subdirectory (for example `cfdof`) in the following firectory created by podman:  
    `\\wsl$\podman-machine-default\home\user`
    * In the cfdof preference page, set the default output directory as above:  
    `\\wsl$\podman-machine-default\home\user\cfdof`


### PR DESCRIPTION
Windows 11 expands the wsl$ to wsl.local.  Fix for this.
Also improved handling of the detection of the output directory change.