### PR TITLE
Add support for using a relative path for the Output Path

### DIFF
--- a/CfdOF/CfdTools.py
+++ b/CfdOF/CfdTools.py
@@ -668,7 +668,7 @@ def translatePath(p):
     Transform path to the perspective of the Linux subsystem in which OpenFOAM is run (e.g. mingw)
     """
     if platform.system() == 'Windows':
-        return fromWindowsPath(p)
+        return fromWindowsPath(os.path.abspath(p))
     else:
         return p
 

--- a/CfdOF/Solve/CfdCaseWriterFoam.py
+++ b/CfdOF/Solve/CfdCaseWriterFoam.py
@@ -51,7 +51,7 @@ class CfdCaseWriterFoam:
         self.zone_objs = CfdTools.getZoneObjects(analysis_obj)
         self.dynamic_mesh_refinement_obj = CfdTools.getDynamicMeshAdaptation(analysis_obj)
         self.mesh_generated = False
-        self.working_dir = CfdTools.getOutputPath(self.analysis_obj)
+        self.working_dir = os.path.abspath(CfdTools.getOutputPath(self.analysis_obj))
         self.progressCallback = None
 
         self.settings = None


### PR DESCRIPTION
This change adds support for using a relative path for the CfdAnalysis Output Path by converting the entered path to an absolute path. This is useful when sharing projects that use CfdAnalysis with others, as you can use a relative path within the project directory. I tested this by running an analysis using CfdOF with the Output Path set to . within FreeCAD on Windows 10 Pro.