### PR TITLE
[feat] Configurable writePrecision and resuming simulation solving

### DIFF
--- a/CfdOF/Solve/CfdSolverFoam.py
+++ b/CfdOF/Solve/CfdSolverFoam.py
@@ -33,6 +33,10 @@ if FreeCAD.GuiUp:
     from PySide import QtCore
 
 
+# Constants
+START_FROM = ["startTime", "latestTime"]
+
+
 def makeCfdSolverFoam(name="CfdSolver"):
     obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython", name)
     CfdSolverFoam(obj)
@@ -95,6 +99,11 @@ class CfdSolverFoam(object):
                           "Iteration output interval")
         addObjectProperty(obj, "ConvergenceTol", 1e-3, "App::PropertyFloat", "IterationControl",
                           "Global absolute solution convergence criterion")
+
+        if addObjectProperty(obj, "StartFrom", START_FROM,
+                             "App::PropertyEnumeration", "TimeStepControl",
+                             "Whether to restart or resume solving"):
+            obj.StartFrom = START_FROM[0]
         addObjectProperty(obj, "EndTime", "1 s", "App::PropertyQuantity", "TimeStepControl",
                           "Total time to run transient solution")
         addObjectProperty(obj, "TimeStep", "0.001 s", "App::PropertyQuantity", "TimeStepControl",

--- a/CfdOF/Solve/CfdSolverFoam.py
+++ b/CfdOF/Solve/CfdSolverFoam.py
@@ -86,6 +86,8 @@ class CfdSolverFoam(object):
                           "Number of cores on which to run parallel analysis")
         addObjectProperty(obj, "PurgeWrite", 0, "App::PropertyInteger", "Solver",
                           "Sets a limit on the number of time directories that are stored by overwriting time directories on a cyclic basis.  Set to 0 to disable")
+        addObjectProperty(obj, "WritePrecision", 8, "App::PropertyInteger", "Solver",
+                          "Precision of quantities written at each timestep")
 
         addObjectProperty(obj, "MaxIterations", 2000, "App::PropertyInteger", "IterationControl",
                           "Maximum number of iterations to run steady-state analysis")

--- a/Data/Templates/case/Allrun
+++ b/Data/Templates/case/Allrun
@@ -115,7 +115,7 @@ PNAME=p
 %{%(solver/Parallel%)
 %:True
 # Parallel decomposition
-runCommand decomposePar -force
+runCommand decomposePar -force -ifRequired
 
 # Pick up number of parallel processes
 NPROC=$(foamDictionary -entry "numberOfSubdomains" -value system/decomposeParDict)

--- a/Data/Templates/case/system/controlDict
+++ b/Data/Templates/case/system/controlDict
@@ -56,7 +56,7 @@ maxAlphaCo      %(solver/MaxInterfaceCFLNumber%);
 %}
 writeFormat     ascii;
 
-writePrecision  8;
+writePrecision  %(solver/WritePrecision%);
 
 runTimeModifiable true;
 

--- a/Data/Templates/case/system/controlDict
+++ b/Data/Templates/case/system/controlDict
@@ -10,7 +10,7 @@ FoamFile
 
 application     %(solver/SolverName%);
 
-startFrom       startTime;
+startFrom       %(solver/StartFrom%);
 
 startTime       0;
 

--- a/Data/TestFiles/cases/DamBreak3D/case/Allrun
+++ b/Data/TestFiles/cases/DamBreak3D/case/Allrun
@@ -73,7 +73,7 @@ runCommand topoSet -dict system/topoSetZonesDict
 runCommand setFields
 
 # Parallel decomposition
-runCommand decomposePar -force
+runCommand decomposePar -force -ifRequired
 
 # Pick up number of parallel processes
 NPROC=$(foamDictionary -entry "numberOfSubdomains" -value system/decomposeParDict)

--- a/Data/TestFiles/cases/Duct/case/Allrun
+++ b/Data/TestFiles/cases/Duct/case/Allrun
@@ -62,7 +62,7 @@ runCommand topoSet -dict system/topoSetZonesDict
 PNAME=p
 
 # Parallel decomposition
-runCommand decomposePar -force
+runCommand decomposePar -force -ifRequired
 
 # Pick up number of parallel processes
 NPROC=$(foamDictionary -entry "numberOfSubdomains" -value system/decomposeParDict)

--- a/Data/TestFiles/cases/Elbow/case/Allrun
+++ b/Data/TestFiles/cases/Elbow/case/Allrun
@@ -59,7 +59,7 @@ runCommand createPatch -overwrite
 PNAME=p
 
 # Parallel decomposition
-runCommand decomposePar -force
+runCommand decomposePar -force -ifRequired
 
 # Pick up number of parallel processes
 NPROC=$(foamDictionary -entry "numberOfSubdomains" -value system/decomposeParDict)

--- a/Data/TestFiles/cases/LESStep/case/Allrun
+++ b/Data/TestFiles/cases/LESStep/case/Allrun
@@ -57,7 +57,7 @@ fi
 runCommand createPatch -overwrite
 
 # Parallel decomposition
-runCommand decomposePar -force
+runCommand decomposePar -force -ifRequired
 
 # Pick up number of parallel processes
 NPROC=$(foamDictionary -entry "numberOfSubdomains" -value system/decomposeParDict)

--- a/Data/TestFiles/cases/LESStep/case/system/controlDict
+++ b/Data/TestFiles/cases/LESStep/case/system/controlDict
@@ -15,7 +15,7 @@ FoamFile
 
 application     pimpleFoam;
 
-startFrom       startTime;
+startFrom       latestTime;
 
 startTime       0;
 

--- a/Data/TestFiles/cases/LESStep/case/system/controlDict
+++ b/Data/TestFiles/cases/LESStep/case/system/controlDict
@@ -37,7 +37,7 @@ maxCo           5.0;
 
 writeFormat     ascii;
 
-writePrecision  8;
+writePrecision  16;
 
 runTimeModifiable true;
 

--- a/Data/TestFiles/cases/Projectile/case/Allrun
+++ b/Data/TestFiles/cases/Projectile/case/Allrun
@@ -57,7 +57,7 @@ fi
 runCommand createPatch -overwrite
 
 # Parallel decomposition
-runCommand decomposePar -force
+runCommand decomposePar -force -ifRequired
 
 # Pick up number of parallel processes
 NPROC=$(foamDictionary -entry "numberOfSubdomains" -value system/decomposeParDict)

--- a/Data/TestFiles/cases/UAV/case/Allrun
+++ b/Data/TestFiles/cases/UAV/case/Allrun
@@ -59,7 +59,7 @@ runCommand createPatch -overwrite
 PNAME=p
 
 # Parallel decomposition
-runCommand decomposePar -force
+runCommand decomposePar -force -ifRequired
 
 # Pick up number of parallel processes
 NPROC=$(foamDictionary -entry "numberOfSubdomains" -value system/decomposeParDict)

--- a/Data/TestFiles/cases/ViscousTubeBundle/case/Allrun
+++ b/Data/TestFiles/cases/ViscousTubeBundle/case/Allrun
@@ -59,7 +59,7 @@ runCommand createPatch -overwrite
 PNAME=p
 
 # Parallel decomposition
-runCommand decomposePar -force
+runCommand decomposePar -force -ifRequired
 
 # Pick up number of parallel processes
 NPROC=$(foamDictionary -entry "numberOfSubdomains" -value system/decomposeParDict)

--- a/Demos/LESStep/backwardStep.FCMacro
+++ b/Demos/LESStep/backwardStep.FCMacro
@@ -38,6 +38,7 @@ obj.gz = '0 mm/s^2'
 
 FreeCAD.ActiveDocument.FluidProperties.Material = {'Name': 'Air', 'Description': 'Standard air properties at 20 Degrees Celsius and 1 atm', 'Density': '1.20 kg/m^3', 'DynamicViscosity': '1.80e-5 kg/m/s', 'MolarMass': '0.0289643897748887 kg/mol', 'Cp': '1004.703 J/kg/K', 'SutherlandConstant': '1.4579326545176254e-06 kg/m/s/K^0.5', 'SutherlandTemperature': '110.4 K'}
 
+FreeCAD.ActiveDocument.CfdSolver.StartFrom = "latestTime"
 FreeCAD.ActiveDocument.CfdSolver.WritePrecision = 16
 
 from CfdOF.Solve import CfdFluidBoundary

--- a/Demos/LESStep/backwardStep.FCMacro
+++ b/Demos/LESStep/backwardStep.FCMacro
@@ -38,6 +38,8 @@ obj.gz = '0 mm/s^2'
 
 FreeCAD.ActiveDocument.FluidProperties.Material = {'Name': 'Air', 'Description': 'Standard air properties at 20 Degrees Celsius and 1 atm', 'Density': '1.20 kg/m^3', 'DynamicViscosity': '1.80e-5 kg/m/s', 'MolarMass': '0.0289643897748887 kg/mol', 'Cp': '1004.703 J/kg/K', 'SutherlandConstant': '1.4579326545176254e-06 kg/m/s/K^0.5', 'SutherlandTemperature': '110.4 K'}
 
+FreeCAD.ActiveDocument.CfdSolver.WritePrecision = 16
+
 from CfdOF.Solve import CfdFluidBoundary
 CfdTools.getActiveAnalysis().addObject(CfdFluidBoundary.makeCfdFluidBoundary())
 

--- a/metadata.txt
+++ b/metadata.txt
@@ -8,7 +8,7 @@ description=Computational Fluid Dynamics (CFD) analysis based on OpenFOAM
 about=Simple workflow to get started with CFD analysis.
       Supports incompressible laminar and turbulent flow, basic multiphase flow,
       and cut-cell cartesian meshing
-version=1.24.1
+version=1.24.2
 tracker=https://forum.freecadweb.org/viewforum.php?f=37&sid=3d90858d2ff441bd10475a693b55643a
 repository=https://github.com/jaheyns/cfdof
 license=LGPL

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package format="1">
     <name>CfdOF</name>
     <description>Computational Fluid Dynamics (CFD) for FreeCAD based on OpenFOAM</description>
-    <version>1.24.1</version>
+    <version>1.24.2</version>
     <maintainer email="oliveroxtoby@gmail.com">Oliver Oxtoby</maintainer>
     <license file="LICENSE">LGPL-2</license>
     <url type="repository" branch="master">https://github.com/jaheyns/CfdOF</url>


### PR DESCRIPTION
I've tested the second commit - resuming from the latest timestep in a number of different configurations here and not had any issues with it. It seems to do the correct thing and restart the simulation when required.

I added testing these two new properties in the `LESStep` demo. It shouldn't have any material impact and the tests still pass.

I haven't explicitly added a test that stops and resumes a solve as it seems tricky to avoid any timing issues and would add a lot of complexity.