### PR TITLE
Make license match SPDX ID

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
     <description>Computational Fluid Dynamics (CFD) for FreeCAD based on OpenFOAM</description>
     <version>1.25.1</version>
     <maintainer email="oliveroxtoby@gmail.com">Oliver Oxtoby</maintainer>
-    <license file="LICENSE">LGPL-2</license>
+    <license file="LICENSE">LGPL-2.0-or-later</license>
     <url type="repository" branch="master">https://github.com/jaheyns/CfdOF</url>
     <url type="documentation">https://github.com/jaheyns/CfdOF/README.md</url>
     <freecadmin>0.20.0</freecadmin>


### PR DESCRIPTION
See https://spdx.org/licenses/ -- note that you might actually mean `LGPL-2.1-only`, in which case use that instead.
