### PR TITLE
Fix issue where pressure data is not loaded into the fluid baundary panel

### DIFF
--- a/CfdOF/Solve/TaskPanelCfdFluidBoundary.py
+++ b/CfdOF/Solve/TaskPanelCfdFluidBoundary.py
@@ -90,6 +90,7 @@ class TaskPanelCfdFluidBoundary:
         setQuantity(self.form.inputVelocityMag, self.obj.VelocityMag)
         self.form.lineDirection.setText(self.obj.DirectionFace)
         self.form.checkReverse.setChecked(self.obj.ReverseNormal)
+        setQuantity(self.form.inputPressure, self.obj.Pressure)
         setQuantity(self.form.inputAngularVelocity, self.obj.AngularVelocity)
         setQuantity(self.form.inputRotationOriginX, self.obj.RotationOrigin.x)
         setQuantity(self.form.inputRotationOriginY, self.obj.RotationOrigin.y)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package format="1">
     <name>CfdOF</name>
     <description>Computational Fluid Dynamics (CFD) for FreeCAD based on OpenFOAM</description>
-    <version>1.30.1</version>
+    <version>1.30.2</version>
     <maintainer email="oliveroxtoby@gmail.com">Oliver Oxtoby</maintainer>
     <license file="LICENSE">LGPL-2.0-or-later</license>
     <url type="repository" branch="master">https://github.com/jaheyns/CfdOF</url>


### PR DESCRIPTION
The pressure data was not being loaded into the Fluid Boundary panel upon opening, causing the corresponding field to show 0 Pa each time the panel was opened.
This PR fixes the issue.
![image](https://github.com/user-attachments/assets/5ac897ff-8fbd-4d23-8143-7acceea88f69)
