### PR TITLE
Fix a UI issue where once SRF was enabled, it could not be disabled

### DIFF
--- a/CfdOF/Solve/TaskPanelCfdPhysicsSelection.py
+++ b/CfdOF/Solve/TaskPanelCfdPhysicsSelection.py
@@ -230,8 +230,8 @@ class TaskPanelCfdPhysicsSelection:
         storeIfChanged(self.obj, 'gy', getQuantity(self.form.gy))
         storeIfChanged(self.obj, 'gz', getQuantity(self.form.gz))
 
+        storeIfChanged(self.obj, 'SRFModelEnabled', self.form.srfCheckBox.isChecked())
         if self.form.srfCheckBox.isChecked():
-            storeIfChanged(self.obj, 'SRFModelEnabled', self.form.srfCheckBox.isChecked())
             storeIfChanged(self.obj, 'SRFModelRPM', self.form.inputSRFRPM.text())
             centre_of_rotation = FreeCAD.Vector(
                 self.form.inputSRFCoRx.property("quantity").Value,

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package format="1">
     <name>CfdOF</name>
     <description>Computational Fluid Dynamics (CFD) for FreeCAD based on OpenFOAM</description>
-    <version>1.30.2</version>
+    <version>1.30.3</version>
     <maintainer email="oliveroxtoby@gmail.com">Oliver Oxtoby</maintainer>
     <license file="LICENSE">LGPL-2.0-or-later</license>
     <url type="repository" branch="master">https://github.com/jaheyns/CfdOF</url>


### PR DESCRIPTION
I found an issue where SRF could not be disabled from the UI after being enabled, so I fixed it.
It might be better to remove the `if` statement on line 233 (234) altogether, but I chose a solution with minimal changes.
![image](https://github.com/user-attachments/assets/dabadfc8-9626-4aa9-9508-a123d69b042f)
