### PR TITLE
Prepare for QCheckBox stateChanged -> checkStateChanged

### DIFF
--- a/CfdOF/Mesh/TaskPanelCfdMeshRefinement.py
+++ b/CfdOF/Mesh/TaskPanelCfdMeshRefinement.py
@@ -65,7 +65,10 @@ class TaskPanelCfdMeshRefinement:
                                                                      False,
                                                                      True)
 
-        self.form.check_boundlayer.stateChanged.connect(self.updateUI)
+        if hasattr(self.form.check_boundlayer, "checkStateChanged"):
+            self.form.check_boundlayer.checkStateChanged.connect(self.updateUI)
+        else:
+            self.form.check_boundlayer.stateChanged.connect(self.updateUI)
 
         self.form.extrusionTypeCombo.addItems(CfdMeshRefinement.EXTRUSION_NAMES)
         self.form.extrusionTypeCombo.currentIndexChanged.connect(self.updateUI)

--- a/CfdOF/Solve/TaskPanelCfdFluidBoundary.py
+++ b/CfdOF/Solve/TaskPanelCfdFluidBoundary.py
@@ -210,7 +210,10 @@ class TaskPanelCfdFluidBoundary:
         self.form.comboFluid.currentIndexChanged.connect(self.comboFluidChanged)
         self.form.inputVolumeFraction.valueChanged.connect(self.inputVolumeFractionChanged)
         self.form.comboThermalBoundaryType.currentIndexChanged.connect(self.updateUI)
-        self.form.checkBoxDefaultBoundary.stateChanged.connect(self.updateUI)
+        if hasattr(self.form.checkBoxDefaultBoundary, "checkStateChanged"):
+            self.form.checkBoxDefaultBoundary.checkStateChanged.connect(self.updateUI)
+        else:
+            self.form.checkBoxDefaultBoundary.stateChanged.connect(self.updateUI)
         self.form.radioButtonMasterPeriodic.toggled.connect(self.updateUI)
         self.form.radioButtonSlavePeriodic.toggled.connect(self.updateUI)
         self.form.rb_rotational_periodic.toggled.connect(self.updateUI)

--- a/CfdOF/Solve/TaskPanelCfdFluidProperties.py
+++ b/CfdOF/Solve/TaskPanelCfdFluidProperties.py
@@ -53,8 +53,10 @@ class TaskPanelCfdFluidProperties:
         self.form.compressibleCheckBox.setVisible(self.physics_obj.Flow == "NonIsothermal")
         # Make sure it is checked in the default case since object was initialised with Isothermal
         self.form.compressibleCheckBox.setChecked(self.material.get('Type') != "Incompressible")
-        self.form.compressibleCheckBox.stateChanged.connect(self.updateUI)
-
+        if hasattr(self.form.compressibleCheckBox, "checkStateChanged"):
+            self.form.compressibleCheckBox.checkStateChanged.connect(self.updateUI)
+        else:
+            self.form.compressibleCheckBox.stateChanged.connect(self.updateUI)
         self.text_boxes = {}
         self.fields = []
         self.createUI()

--- a/CfdOF/Solve/TaskPanelCfdPhysicsSelection.py
+++ b/CfdOF/Solve/TaskPanelCfdPhysicsSelection.py
@@ -48,9 +48,14 @@ class TaskPanelCfdPhysicsSelection:
         self.form.radioButtonTransient.toggled.connect(self.updateUI)
         self.form.radioButtonSinglePhase.toggled.connect(self.updateUI)
         self.form.radioButtonFreeSurface.toggled.connect(self.updateUI)
-        self.form.checkBoxIsothermal.stateChanged.connect(self.updateUI)
-        self.form.viscousCheckBox.stateChanged.connect(self.updateUI)
-        self.form.srfCheckBox.stateChanged.connect(self.updateUI)
+        if hasattr(self.form.checkBoxIsothermal, "checkStateChanged"):
+            self.form.checkBoxIsothermal.checkStateChanged.connect(self.updateUI)
+            self.form.viscousCheckBox.checkStateChanged.connect(self.updateUI)
+            self.form.srfCheckBox.checkStateChanged.connect(self.updateUI)
+        else:
+            self.form.checkBoxIsothermal.stateChanged.connect(self.updateUI)
+            self.form.viscousCheckBox.stateChanged.connect(self.updateUI)
+            self.form.srfCheckBox.stateChanged.connect(self.updateUI)
         self.form.radioButtonLaminar.toggled.connect(self.updateUI)
         self.form.radioButtonRANS.toggled.connect(self.updateUI)
         self.form.radioButtonDES.toggled.connect(self.updateUI)

--- a/CfdOF/Solve/TaskPanelCfdZone.py
+++ b/CfdOF/Solve/TaskPanelCfdZone.py
@@ -86,10 +86,16 @@ class TaskPanelCfdZone:
             self.form.frameInitialisationZone.setVisible(True)
 
             self.form.comboFluid.currentIndexChanged.connect(self.comboFluidChanged)
-            self.form.checkAlpha.stateChanged.connect(self.updateUI)
-            self.form.checkVelocity.stateChanged.connect(self.updateUI)
-            self.form.checkPressure.stateChanged.connect(self.updateUI)
-            self.form.checkTemperature.stateChanged.connect(self.updateUI)
+            if hasattr(self.form.checkAlpha, "checkStateChanged"):
+                self.form.checkAlpha.checkStateChanged.connect(self.updateUI)
+                self.form.checkVelocity.checkStateChanged.connect(self.updateUI)
+                self.form.checkPressure.checkStateChanged.connect(self.updateUI)
+                self.form.checkTemperature.checkStateChanged.connect(self.updateUI)
+            else:
+                self.form.checkAlpha.stateChanged.connect(self.updateUI)
+                self.form.checkVelocity.stateChanged.connect(self.updateUI)
+                self.form.checkPressure.stateChanged.connect(self.updateUI)
+                self.form.checkTemperature.stateChanged.connect(self.updateUI)
             self.form.inputVolumeFraction.valueChanged.connect(self.inputVolumeFractionChanged)
 
             material_objs = CfdTools.getMaterials(CfdTools.getParentAnalysisObject(obj))

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package format="1">
     <name>CfdOF</name>
     <description>Computational Fluid Dynamics (CFD) for FreeCAD based on OpenFOAM</description>
-    <version>1.30.4</version>
+    <version>1.30.5</version>
     <maintainer email="oliveroxtoby@gmail.com">Oliver Oxtoby</maintainer>
     <license file="LICENSE">LGPL-2.0-or-later</license>
     <url type="repository" branch="master">https://github.com/jaheyns/CfdOF</url>


### PR DESCRIPTION
Due to Deprecation warnings already being raised in Qt6.9.0 and to maintain backwards compatibility to Qt5.x this PR allows all current supported builds to still function as expected.
I prefer to use the attribute lookup than have PySide version checks but by all means advise if changes are required.