### PR TITLE
Support for running docker / podman image from Flatpak FreeCAD

### DIFF
--- a/CfdOF/CfdTools.py
+++ b/CfdOF/CfdTools.py
@@ -852,7 +852,7 @@ def makeRunCommand(cmd, dir=None, source_env=True):
             cmd = 'chmod 744 {0} && {0}'.format(cmd)  # If using windows wsl$ output directory, need to make the command executable
         if 'podman' in docker_container.docker_cmd:
             cmd = f'export OMPI_ALLOW_RUN_AS_ROOT=1 && export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 && {cmd}'
-        cmdline = [docker_container.docker_cmd, 'exec', docker_container.container_id, 'bash', '-c', source + cd + cmd]
+        cmdline = docker_container.docker_cmd.split() + ['exec', docker_container.container_id, 'bash', '-c', source + cd + cmd]
         print('Using command: ' + ' '.join(cmdline))
         return cmdline
 
@@ -1855,10 +1855,15 @@ class DockerContainer:
             else:
                 usr_str = "-u{}:{}".format(os.getuid(),os.getgid())
 
-        cmd = [self.docker_cmd, "run", "-t", "-d", usr_str, "-v" + output_path + ":/tmp", self.image_name]
+        cmd = self.docker_cmd.split() + + ["run", "-t", "-d", usr_str, "-v" + output_path + ":/tmp", self.image_name]
 
         if 'podman' in self.docker_cmd:
-            cmd.insert(2, "--security-opt=label=disable") # Allows /tmp to be mounted to the podman container
+            if 'flatpak' in self.docker_cmd:
+                insert_place = 4
+            else:
+                insert_place = 2
+            # Allows /tmp to be mounted to the podman container
+            cmd.insert(insert_place, "--security-opt=label=disable")
 
         # if 'docker' in self.docker_cmd:
         #     cmd = cmd.replace('docker.io/','')

--- a/CfdOF/CfdTools.py
+++ b/CfdOF/CfdTools.py
@@ -1798,16 +1798,23 @@ class DockerContainer:
     def __init__(self):
         self.image_name = None
         import shutil
+        import subprocess
 
-        if shutil.which('podman') is not None:
-            self.docker_cmd = shutil.which('podman')
-        elif shutil.which('docker') is not None:
-            self.docker_cmd = shutil.which('docker')
+        podman_dir = shutil.which('podman')
+        docker_dir = shutil.which('docker')
+        podman_flatpak = str(subprocess.run(['flatpak-spawn', '--host', 'podman'], capture_output=True).stdout)
+        docker_flatpak = str(subprocess.run(['flatpak-spawn', '--host', 'docker'], capture_output=True).stderr)
+
+        if podman_dir is not None:
+            self.docker_cmd = podman_dir.split(os.path.sep)[-1]
+        elif docker_dir is not None:
+            self.docker_cmd = docker_dir.split(os.path.sep)[-1]
+        elif 'failed' not in podman_flatpak:
+            self.docker_cmd = 'flatpak-spawn --host podman'
+        elif 'failed' not in docker_flatpak:
+            self.docker_cmd = 'flatpak-spawn --host docker'
         else:
             self.docker_cmd = None
-
-        if self.docker_cmd is not None:
-            self.docker_cmd = self.docker_cmd.split(os.path.sep)[-1]
 
     def start_container(self):
         prefs = getPreferencesLocation()

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package format="1">
     <name>CfdOF</name>
     <description>Computational Fluid Dynamics (CFD) for FreeCAD based on OpenFOAM</description>
-    <version>1.31.6</version>
+    <version>1.31.7</version>
     <maintainer email="oliveroxtoby@gmail.com">Oliver Oxtoby</maintainer>
     <license file="LICENSE">LGPL-2.0-or-later</license>
     <url type="repository" branch="master">https://github.com/jaheyns/CfdOF</url>


### PR DESCRIPTION
Simple implementation of #215 
Tested both docker / podman within Flatpak. Successful dependency check logs attached below. 
[dependency_check_docker.txt](https://github.com/user-attachments/files/21905177/dependency_check_docker.txt)
[dependency_check_podman.txt](https://github.com/user-attachments/files/21905178/dependency_check_podman.txt)