### PR TITLE
fix pythonopen not found on python3.13

### DIFF
--- a/CfdOF/CfdImportSTL.py
+++ b/CfdOF/CfdImportSTL.py
@@ -29,7 +29,7 @@ import tempfile
 # in a single STL file
 
 # Python's open is masked by the function below
-if open.__module__ in ['__builtin__','io']:
+if open.__module__ in ['__builtin__','io','_io']:
     pythonopen = open
 
 


### PR DESCRIPTION
when using python3.13 it did not make the `pythonopen` because for some reason they decided to change `io` to `_io`