### PR TITLE
Guard module-scope addCommand() calls with FreeCAD.GuiUp

### DIFF
--- a/CfdOF/CfdAnalysis.py
+++ b/CfdOF/CfdAnalysis.py
@@ -280,4 +280,5 @@ class _ViewProviderCfdAnalysis:
         return None
 
 
-FreeCADGui.addCommand('CfdOF_Analysis', CommandCfdAnalysis())
+if FreeCAD.GuiUp:
+    FreeCADGui.addCommand('CfdOF_Analysis', CommandCfdAnalysis())

--- a/CfdOF/CfdReloadWorkbench.py
+++ b/CfdOF/CfdReloadWorkbench.py
@@ -47,4 +47,5 @@ class CommandCfdReloadWorkbench:
     def Activated(self):
         CfdTools.reloadWorkbench()
 
-FreeCADGui.addCommand('CfdOF_ReloadWorkbench', CommandCfdReloadWorkbench())
+if FreeCAD.GuiUp:
+    FreeCADGui.addCommand('CfdOF_ReloadWorkbench', CommandCfdReloadWorkbench())

--- a/CfdOF/CfdTestCommands.py
+++ b/CfdOF/CfdTestCommands.py
@@ -87,6 +87,7 @@ class CommandCfdCleanTests:
         cleanCfdUnitTests()
 
 
-FreeCADGui.addCommand('CfdOF_RunTests', CommandCfdRunTests())
-FreeCADGui.addCommand('CfdOF_UpdateTestData', CommandCfdUpdateTestData())
-FreeCADGui.addCommand('CfdOF_CleanTests', CommandCfdCleanTests())
+if FreeCAD.GuiUp:
+    FreeCADGui.addCommand('CfdOF_RunTests', CommandCfdRunTests())
+    FreeCADGui.addCommand('CfdOF_UpdateTestData', CommandCfdUpdateTestData())
+    FreeCADGui.addCommand('CfdOF_CleanTests', CommandCfdCleanTests())

--- a/CfdOF/Mesh/CfdDynamicMeshRefinement.py
+++ b/CfdOF/Mesh/CfdDynamicMeshRefinement.py
@@ -545,6 +545,7 @@ class ViewProviderCfdDynamicMeshShockRefinement:
         return None
 
 
-FreeCADGui.addCommand('CfdOF_DynamicMeshInterfaceRefinement', CommandDynamicMeshInterfaceRefinement())
-FreeCADGui.addCommand('CfdOF_DynamicMeshShockRefinement', CommandDynamicMeshShockRefinement())
-FreeCADGui.addCommand('CfdOF_GroupDynamicMeshRefinement', CommandGroupDynamicMeshRefinement())
+if FreeCAD.GuiUp:
+    FreeCADGui.addCommand('CfdOF_DynamicMeshInterfaceRefinement', CommandDynamicMeshInterfaceRefinement())
+    FreeCADGui.addCommand('CfdOF_DynamicMeshShockRefinement', CommandDynamicMeshShockRefinement())
+    FreeCADGui.addCommand('CfdOF_GroupDynamicMeshRefinement', CommandGroupDynamicMeshRefinement())

--- a/CfdOF/Mesh/CfdMesh.py
+++ b/CfdOF/Mesh/CfdMesh.py
@@ -406,4 +406,5 @@ class _ViewProviderCfdMesh:
         return None
 
 
-FreeCADGui.addCommand('CfdOF_MeshFromShape', CommandCfdMeshFromShape())
+if FreeCAD.GuiUp:
+    FreeCADGui.addCommand('CfdOF_MeshFromShape', CommandCfdMeshFromShape())

--- a/CfdOF/Mesh/CfdMeshRefinement.py
+++ b/CfdOF/Mesh/CfdMeshRefinement.py
@@ -448,4 +448,5 @@ class _ViewProviderCfdMeshRefinement:
         return None
 
 
-FreeCADGui.addCommand('CfdOF_MeshRegion', CommandMeshRegion())
+if FreeCAD.GuiUp:
+    FreeCADGui.addCommand('CfdOF_MeshRegion', CommandMeshRegion())

--- a/CfdOF/PostProcess/CfdReportingFunction.py
+++ b/CfdOF/PostProcess/CfdReportingFunction.py
@@ -366,4 +366,5 @@ class _ViewProviderCfdReportingFunctions:
         return None
 
 
-FreeCADGui.addCommand('CfdOF_ReportingFunctions', CommandCfdReportingFunction())
+if FreeCAD.GuiUp:
+    FreeCADGui.addCommand('CfdOF_ReportingFunctions', CommandCfdReportingFunction())

--- a/CfdOF/Solve/CfdFluidBoundary.py
+++ b/CfdOF/Solve/CfdFluidBoundary.py
@@ -943,4 +943,5 @@ class _ViewProviderCfdFluidBoundary:
         return None
 
 
-FreeCADGui.addCommand('CfdOF_FluidBoundary', CommandCfdFluidBoundary())
+if FreeCAD.GuiUp:
+    FreeCADGui.addCommand('CfdOF_FluidBoundary', CommandCfdFluidBoundary())

--- a/CfdOF/Solve/CfdFluidMaterial.py
+++ b/CfdOF/Solve/CfdFluidMaterial.py
@@ -222,4 +222,5 @@ class _ViewProviderCfdFluidMaterial:
         return None
 
 
-FreeCADGui.addCommand('CfdOF_FluidMaterial', CommandCfdFluidMaterial())
+if FreeCAD.GuiUp:
+    FreeCADGui.addCommand('CfdOF_FluidMaterial', CommandCfdFluidMaterial())

--- a/CfdOF/Solve/CfdInitialiseFlowField.py
+++ b/CfdOF/Solve/CfdInitialiseFlowField.py
@@ -379,4 +379,5 @@ class _ViewProviderCfdInitialseInternalFlowField:
         return None
 
 
-FreeCADGui.addCommand('CfdOF_InitialiseInternal', CommandCfdInitialiseInternalFlowField())
+if FreeCAD.GuiUp:
+    FreeCADGui.addCommand('CfdOF_InitialiseInternal', CommandCfdInitialiseInternalFlowField())

--- a/CfdOF/Solve/CfdMeanVelocityForce.py
+++ b/CfdOF/Solve/CfdMeanVelocityForce.py
@@ -237,4 +237,5 @@ class _ViewProviderCfdMeanVelocityForce:
         return None
 
 
-FreeCADGui.addCommand('CfdOF_MeanVelocityForce', CommandCfdMeanVelocityForce())
+if FreeCAD.GuiUp:
+    FreeCADGui.addCommand('CfdOF_MeanVelocityForce', CommandCfdMeanVelocityForce())

--- a/CfdOF/Solve/CfdPhysicsSelection.py
+++ b/CfdOF/Solve/CfdPhysicsSelection.py
@@ -356,4 +356,5 @@ class _ViewProviderPhysicsSelection:
         return None
 
 
-FreeCADGui.addCommand('CfdOF_PhysicsModel', CommandCfdPhysicsSelection())
+if FreeCAD.GuiUp:
+    FreeCADGui.addCommand('CfdOF_PhysicsModel', CommandCfdPhysicsSelection())

--- a/CfdOF/Solve/CfdScalarTransportFunction.py
+++ b/CfdOF/Solve/CfdScalarTransportFunction.py
@@ -249,4 +249,5 @@ class _ViewProviderCfdScalarTransportFunction:
         return None
 
 
-FreeCADGui.addCommand('CfdOF_ScalarTransportFunctions', CommandCfdScalarTransportFunction())
+if FreeCAD.GuiUp:
+    FreeCADGui.addCommand('CfdOF_ScalarTransportFunctions', CommandCfdScalarTransportFunction())

--- a/CfdOF/Solve/CfdSolverFoam.py
+++ b/CfdOF/Solve/CfdSolverFoam.py
@@ -403,4 +403,5 @@ class _ViewProviderCfdSolverFoam:
         return None
 
 
-FreeCADGui.addCommand('CfdOF_SolverControl', CommandCfdSolverFoam())
+if FreeCAD.GuiUp:
+    FreeCADGui.addCommand('CfdOF_SolverControl', CommandCfdSolverFoam())

--- a/CfdOF/Solve/CfdZone.py
+++ b/CfdOF/Solve/CfdZone.py
@@ -505,5 +505,6 @@ class _ViewProviderCfdZone:
         return None
 
 
-FreeCADGui.addCommand('CfdOF_PorousZone', CommandCfdPorousZone())
-FreeCADGui.addCommand('CfdOF_InitialisationZone', CommandCfdInitialisationZone())
+if FreeCAD.GuiUp:
+    FreeCADGui.addCommand('CfdOF_PorousZone', CommandCfdPorousZone())
+    FreeCADGui.addCommand('CfdOF_InitialisationZone', CommandCfdInitialisationZone())


### PR DESCRIPTION
## Summary

`FreeCADGui.addCommand()` is called unguarded at module scope in 15 files, even though the `import FreeCADGui` immediately above each call is already guarded with `if FreeCAD.GuiUp:`. Importing any of these modules without a GUI present (e.g. via `freecadcmd`, or any headless script/test harness) raises `NameError: name 'FreeCADGui' is not defined`.

This makes it impossible to script or test the workbench headlessly — every CfdOF module that registers a command hits this.

## Fix

Wrap each addCommand() call (or contiguous run of them) in the same `if FreeCAD.GuiUp:` guard already used for the import above it. GUI behaviour is unchanged: `Init.py` only registers a lazy import type, and the affected modules are imported inside `CfdOFWorkbench.Initialize()`, which runs after `FreeCAD.GuiUp` is set — so the guard only takes effect in the headless case, where the commands couldn't have registered anyway.

`CfdOpenPreferencesPage.py` is intentionally left alone: it imports `FreeCADGui` unconditionally at module scope and is a GUI-only command, so there's no headless code path to protect.

## Testing

Verified by importing the affected modules and running `checkCfdDependencies()` under `freecadcmd` — all import cleanly and the dependency check completes without error. Not run through the full `FreeCAD -t TestCfdOF` GUI-based suite (no GUI-visible behaviour is touched, so no regression expected there, but flagging for visibility).