### PR TITLE
Derive KinematicPressure after the outlet-pressure copy, not before

### DIFF
--- a/CfdOF/Solve/CfdCaseWriterFoam.py
+++ b/CfdOF/Solve/CfdCaseWriterFoam.py
@@ -526,9 +526,10 @@ class CfdCaseWriterFoam:
         """ Do any required computations before case build. Boundary conditions must be processed first. """
         settings = self.settings
         initial_values = settings['initialValues']
-        if settings['solver']['SolverName'] in ['simpleFoam', 'porousSimpleFoam', 'pimpleFoam', 'SRFSimpleFoam']:
-            mat_prop = settings['fluidProperties'][0]
-            initial_values['KinematicPressure'] = initial_values['Pressure'] / mat_prop['Density']
+        # NOTE: KinematicPressure is derived from initial_values['Pressure'] at the
+        # end of this function, after the 'Copy pressure' block below has had a
+        # chance to replace Pressure with the value taken from the outlet boundary.
+        # Deriving it here instead would ignore UseOutletPValue entirely.
         if settings['solver']['SolverName'] in ['interFoam', 'multiphaseInterFoam']:
             # Make sure the first n-1 alpha values exist, and write the n-th one
             # consistently for multiphaseInterFoam
@@ -670,6 +671,13 @@ class CfdCaseWriterFoam:
                 else:
                     raise RuntimeError("No boundary selected to copy initial turbulence values from.")
             #TODO: Check that the required values have actually been set for each turbulent model
+
+        # Incompressible solvers work in kinematic pressure. This must be derived
+        # after the 'Copy pressure' block above, so that an outlet-derived
+        # Pressure (UseOutletPValue) is reflected in the initial field.
+        if settings['solver']['SolverName'] in ['simpleFoam', 'porousSimpleFoam', 'pimpleFoam', 'SRFSimpleFoam']:
+            mat_prop = settings['fluidProperties'][0]
+            initial_values['KinematicPressure'] = initial_values['Pressure'] / mat_prop['Density']
 
     # Function objects (reporting functions, probes)
     def processReportingFunctions(self):


### PR DESCRIPTION
## Summary

`CfdCaseWriterFoam.processInitialConditions()` computed `initialValues['KinematicPressure']` from `initialValues['Pressure']` at the very top of the function — roughly 100 lines before the "Copy pressure" block later in the same function replaces `Pressure` with the value taken from the outlet boundary when `UseOutletPValue` is set.

The result: for `simpleFoam`, `porousSimpleFoam`, `pimpleFoam` and `SRFSimpleFoam`, `UseOutletPValue` has no effect on the written `0/p` field. It's always initialised from the default `1e5 / rho`, regardless of what the outlet boundary is actually configured to.

## Fix

Move the `KinematicPressure` derivation to the end of the function, after the pressure-copy block has had a chance to update `initialValues['Pressure']`. No behavioural change for any case that doesn't use `UseOutletPValue` — the default path (using the raw `Pressure` init value) produces the same result either way, just now correctly reflecting the outlet-derived value when that option is enabled.

## Testing

Verified end to end on a `pitzDaily`-equivalent `simpleFoam` case with `UseOutletPValue = True`: before the fix, `0/p` was written as `uniform 100000.0`; after, `uniform 0.0`, matching the outlet's configured static pressure. Not run through the full `FreeCAD -t TestCfdOF` GUI-based suite — flagging for visibility since I wasn't able to exercise it in this environment.